### PR TITLE
Add weblogic startup script to create and enable a systemd service.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,4 +48,8 @@
       loop_control:
         loop_var: artefact
 
+    - name: Push WL systemd service (and enable service)
+      include: weblogic_startup_service.yml
+      tags: service
+
   when: wls_file.stat.exists == false or force_install|default(false)

--- a/tasks/weblogic_startup_service.yml
+++ b/tasks/weblogic_startup_service.yml
@@ -14,5 +14,4 @@
   systemd:
     name: weblogic.service
     state: stopped
-    enabled: yes
     daemon_reload: yes

--- a/tasks/weblogic_startup_service.yml
+++ b/tasks/weblogic_startup_service.yml
@@ -2,7 +2,6 @@
 
 - name: Create service startup template for admin server
   become: yes
-  become_user: "root"
   template:
     src: 'weblogic.service.j2'
     dest: '/etc/systemd/system/weblogic.service'
@@ -12,9 +11,8 @@
 
 - name: Reload the (new) service which will also start it
   become: yes
-  become_user: "root"
   systemd:
     name: weblogic.service
-    state: reloaded
+    state: stopped
     enabled: yes
     daemon_reload: yes

--- a/tasks/weblogic_startup_service.yml
+++ b/tasks/weblogic_startup_service.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Create service startup template for admin server
+  become: yes
+  become_user: "root"
+  template:
+    src: 'weblogic.service.j2'
+    dest: '/etc/systemd/system/weblogic.service'
+    mode: '0644'
+    owner: "root"
+    group: "root"
+
+- name: Reload the (new) service which will also start it
+  become: yes
+  become_user: "root"
+  systemd:
+    name: weblogic.service
+    state: reloaded
+    enabled: yes
+    daemon_reload: yes

--- a/templates/weblogic.service.j2
+++ b/templates/weblogic.service.j2
@@ -9,10 +9,10 @@ User={{ wls_service_user.name }}
 {% else %}
 User=oracle
 {% endif %}
-WorkingDirectory={{ mw_home | default('/u01/app/oracle/middleware') }}/user_projects/domains/NDelius
-ExecStart={{ mw_home | default('/u01/app/oracle/middleware') }}/user_projects/domains/NDelius/startWebLogic.sh
+WorkingDirectory={{ mw_home | default('/u01/app/oracle/middleware') }}/user_projects/domains/{{ domain_name | default('NDelius') }}/
+ExecStart={{ mw_home | default('/u01/app/oracle/middleware') }}/user_projects/domains/{{ domain_name | default('NDelius') }}/startWebLogic.sh
 Restart=on-failure
-ExecStop={{ mw_home | default('/u01/app/oracle/middleware') }}/user_projects/domains/NDelius/bin/stopWebLogic.sh
+ExecStop={{ mw_home | default('/u01/app/oracle/middleware') }}/user_projects/domains/{{ domain_name | default('NDelius') }}/bin/stopWebLogic.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/weblogic.service.j2
+++ b/templates/weblogic.service.j2
@@ -1,0 +1,18 @@
+[Unit]
+Description=Weblogic Service for nDelius
+After=network.target
+
+[Service]
+Type=simple
+{% if wls_service_user is defined and wls_service_user.name is defined %}
+User={{ wls_service_user.name }}
+{% else %}
+User=oracle
+{% endif %}
+WorkingDirectory={{ mw_home | default('/u01/app/oracle/middleware') }}/user_projects/domains/NDelius
+ExecStart={{ mw_home | default('/u01/app/oracle/middleware') }}/user_projects/domains/NDelius/startWebLogic.sh
+Restart=on-failure
+ExecStop={{ mw_home | default('/u01/app/oracle/middleware') }}/user_projects/domains/NDelius/bin/stopWebLogic.sh
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add weblogic startup script to create and enable a systemd service.
Then enable and run it using systemd through ansible. Note this requires "root" to install the service. The service will attempt to run as the wls set user, but will default to 'oracle' if not set.

I have tested this within the hmpps-delius-core-bootstrap code, then moved it into this repository. I have attempted to use variables set in the script, but have default values in place.
I have had to hard-code the root user in - not sure if there is a better variable for this, but to create the service we require root access.
Also hard-coded is the base domain directory. I couldn't find a variable to use to work out the path name, so it is set to {{ mw_home }} /user_projects/domains/NDelius
